### PR TITLE
Add 3rd party license

### DIFF
--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -1,0 +1,19 @@
+Some files in this repository were created by third parties under the terms of another license, as listed below.
+
+------------------------------------------------------------------------------------------------------------------------
+
+Files:
+
+userscripts/fuzzo.user.js
+
+License:
+
+Copyright (c) 2009, Logan Ingalls
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -55,5 +55,7 @@ and I will add you.
 License
 -------
 
-All contributions are copyright their authors and licensed under the [MIT license](LICENSE),
-meaning they can be freely copied and modified for any purpose.
+All original contributions are copyright their authors and licensed under the [MIT license](LICENSE) unless otherwise noted.
+
+Some files were originally released under another license. Those files and their
+license terms are listed under [LICENSE-3RD-PARTY.txt](LICENSE-3RD-PARTY.txt).


### PR DESCRIPTION
Plutor's scripts are released under the Simplified BSD license, which means we should redistribute that license along with the code. ( http://userscripts-mirror.org/scripts/show/63200 has the original license for Fuzzy Favorites for example. ) Let's list licenses for any third-party files that get pulled in under LICENSE-3RD-PARTY.txt.